### PR TITLE
:bug: resolve form error bug

### DIFF
--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -440,7 +440,7 @@ object FormError {
 
   def apply(key: String, message: String) = new FormError(key, message)
 
-  def apply(key: String, message: String, args: Seq[Any]) = new FormError(key, message, args)
+  def apply(key: String, message: String, args: _*) = new FormError(key, message, args)
 
 }
 

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -237,6 +237,7 @@ case class Form[T](mapping: Mapping[T], data: Map[String, String], errors: Seq[F
     Json.toJson(
       errors.groupBy(_.key).mapValues { errors =>
         errors.map(e => messages(e.message, e.args.map(a => translateMsgArg(a)): _*))
+        // ここで可変長引数で受け取れるようにする
       }
     )
 

--- a/framework/src/play/src/main/scala/play/api/data/Form.scala
+++ b/framework/src/play/src/main/scala/play/api/data/Form.scala
@@ -433,6 +433,7 @@ case class FormError(key: String, messages: Seq[String], args: Seq[Any] = Nil) {
    */
   def format(implicit messages: play.api.i18n.Messages): String = {
     messages.apply(message, args: _*)
+    // ここ直そうと思ったらすでに_*になってた、pullすべきベースブランチ間違えた
   }
 }
 
@@ -440,7 +441,7 @@ object FormError {
 
   def apply(key: String, message: String) = new FormError(key, message)
 
-  def apply(key: String, message: String, args: _*) = new FormError(key, message, args)
+  def apply(key: String, message: String, args: Seq[Any]) = new FormError(key, message, args)
 
 }
 


### PR DESCRIPTION
## 問題
FormError.formatメソッドで適切にフォーマットできない場合がある

## 詳細
例えば以下のようなFormを定義した場合
```
val form = Form(
    mapping(
      "name" -> text,
      "age" -> number(min = -2)
    )(UserData.apply)(UserData.unapply)
```
期待しているエラーメッセージ
`{"age":["minimum -2!"]}`
実際のエラーメッセージ
`[["age","minimum WrappedArray(-2)!"]]`

メモ
- wrappedArrayとは？
  - Seqの子クラス
  - ラッピングする暗黙の変換が行われる
```
val array = Array(1,2,3)
val seq: Seq[Int] = array
-> seq: Seq[Int] = WrappedArray(1,2,3)
```
- Seq型は_*型注釈をつけることで可変長引数に渡すことができる
- 元のコードはSeq[Any]として渡されたものが可変長引数（_*）として受け取られ一要素ずつtranslateMsgArgに渡される
- その変換で暗黙にWrappedArray[Int]になってしまったのはなんでだろう

## 解決策
messageを可変長引数で受け取れるようにするために、FormError.formatメソッドでmessageに渡すargsに_*をつける